### PR TITLE
Small simplification

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -47,19 +47,11 @@ export default class Plugin {
     };
 
     start() {
-        return new Promise (
-            (resolve, reject) => {
-                resolve();
-            }
-        );
+        return Promise.resolve();
     };
 
     stop() {
-        return new Promise (
-            (resolve, reject) => {
-                resolve();
-            }
-        );
+        return Promise.resolve();
     };
 
 }


### PR DESCRIPTION
`new Promise( (resolve, reject) => resolve() )` became `Promise.resolve()`, basically.
